### PR TITLE
Fix datetimezone problems

### DIFF
--- a/src/AppBundle/Controller/UploadController.php
+++ b/src/AppBundle/Controller/UploadController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 use \Malenki\Slug;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Validator\Constraints\DateTime;
 
 class UploadController extends Controller
 {
@@ -82,7 +83,13 @@ class UploadController extends Controller
             $dateTime = null;
 
             if ($exif) {
-                $dateTime = $exif->getCreationDate();
+                $europeBerlin = new \DateTimeZone('Europe/Berlin');
+                $utc = new \DateTimeZone('UTC');
+
+                $dateTimeString = $exif->getCreationDate()->format('Y-m-d H:i:s');
+
+                $dateTime = new \DateTime($dateTimeString, $europeBerlin);
+                $dateTime->setTimezone($utc);
             }
 
             if (!$dateTime || !$exif) {


### PR DESCRIPTION
The problem was in the `UploadController`. The exif reader returned the photo creation datetime in Europe/Berlin as the camera shot in Europe/Berlin, but the `DateTime` object thought the value was UTC.