### PR TITLE
Fix feed routing

### DIFF
--- a/src/AppBundle/Resources/config/routing.xml
+++ b/src/AppBundle/Resources/config/routing.xml
@@ -12,7 +12,7 @@
         <default key="_controller">AppBundle:Feed:index</default>
     </route>
 
-    <route id="feed" path="/plain-feed">
+    <route id="plain-feed" path="/plain-feed">
         <default key="_controller">AppBundle:Feed:plain</default>
     </route>
 


### PR DESCRIPTION
Both rss feeds had the same route name. Fixed this.